### PR TITLE
Shorten and standardise database resource group name

### DIFF
--- a/db.tf
+++ b/db.tf
@@ -1,7 +1,7 @@
 module "tt-database" {
   source                = "git@github.com:hmcts/cnp-module-postgres?ref=postgresql_tf"
   product               = var.product
-  component             = "service"
+  component             = ""
   location              = var.location
   env                   = var.env
   postgresql_user       = var.db_postgresql_user


### PR DESCRIPTION
Real apologies for yet another PR for something so trivial!

This is the one good opportunity to shorten the database resource group name, and standardise it with the naming for other database resource groups.

Name will go from "tax-tribunals-service-stg" to "tax-tribunals-stg"